### PR TITLE
Remove runtime index hints

### DIFF
--- a/bench/benches/timing_bitvec_select.rs
+++ b/bench/benches/timing_bitvec_select.rs
@@ -48,7 +48,13 @@ fn perform_bitvec_select(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], qu
     });
 
     group.bench_function("sucds/Rank9Sel", |b| {
-        let idx = sucds::bit_vectors::Rank9Sel::from_bits(bits.iter().cloned()).select1_hints();
+        let idx = sucds::bit_vectors::Rank9Sel::build_from_bits(
+            bits.iter().cloned(),
+            false,
+            true,
+            false,
+        )
+        .unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });
 

--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -26,9 +26,13 @@ fn show_memories(p: f64) {
     print_memory("Rank9Sel", bytes);
 
     let bytes = {
-        let idx = sucds::bit_vectors::Rank9Sel::from_bits(bits.iter().cloned())
-            .select1_hints()
-            .select0_hints();
+        let idx = sucds::bit_vectors::Rank9Sel::build_from_bits(
+            bits.iter().cloned(),
+            false,
+            true,
+            true,
+        )
+        .unwrap();
         idx.size_in_bytes()
     };
     print_memory("Rank9Sel (with select hints)", bytes);

--- a/src/bit_vectors/rank9sel/inner.rs
+++ b/src/bit_vectors/rank9sel/inner.rs
@@ -168,27 +168,6 @@ impl Rank9SelIndex {
         Rank9SelIndexBuilder::new(bv).build()
     }
 
-    /// Builds an index for faster `select1`.
-    #[must_use]
-    pub fn select1_hints(self) -> Self {
-        self.into_builder().select1_hints().build()
-    }
-
-    /// Builds an index for faster `select0`.
-    #[must_use]
-    pub fn select0_hints(self) -> Self {
-        self.into_builder().select0_hints().build()
-    }
-
-    fn into_builder(self) -> Rank9SelIndexBuilder {
-        Rank9SelIndexBuilder {
-            len: self.len,
-            block_rank_pairs: self.block_rank_pairs.as_ref().to_vec(),
-            select1_hints: self.select1_hints.map(|v| v.as_ref().to_vec()),
-            select0_hints: self.select0_hints.map(|v| v.as_ref().to_vec()),
-        }
-    }
-
     /// Gets the number of bits set.
     #[inline(always)]
     pub fn num_ones(&self) -> usize {
@@ -332,7 +311,7 @@ impl Rank9SelIndex {
     /// use sucds::bit_vectors::{BitVector, rank9sel::inner::Rank9SelIndex};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
-    /// let idx = Rank9SelIndex::new(&bv).select1_hints();
+    /// let idx = Rank9SelIndexBuilder::new(&bv).select1_hints().build();
     ///
     /// unsafe {
     ///     assert_eq!(idx.select1(&bv, 0), Some(0));
@@ -408,7 +387,7 @@ impl Rank9SelIndex {
     /// use sucds::bit_vectors::{BitVector, rank9sel::inner::Rank9SelIndex};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
-    /// let idx = Rank9SelIndex::new(&bv).select0_hints();
+    /// let idx = Rank9SelIndexBuilder::new(&bv).select0_hints().build();
     ///
     /// unsafe {
     ///     assert_eq!(idx.select0(&bv, 0), Some(1));
@@ -563,7 +542,10 @@ mod tests {
     #[test]
     fn test_zero_copy_from_to_bytes() {
         let bv = BitVector::from_bits([false, true, true, false, true]);
-        let idx = Rank9SelIndex::new(&bv).select1_hints().select0_hints();
+        let idx = Rank9SelIndexBuilder::new(&bv)
+            .select1_hints()
+            .select0_hints()
+            .build();
         let bytes = idx.to_bytes();
         let other = Rank9SelIndex::from_bytes(bytes).unwrap();
         assert_eq!(idx, other);


### PR DESCRIPTION
## Summary
- drop methods that added select hints after building `Rank9SelIndex`
- adjust `Rank9Sel` builder code
- update docs, tests and benches to build indexes with hints

## Testing
- `cargo fmt` *(fails: `bash: cargo: command not found`)*
- `cargo test` *(fails: `bash: cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68484de4d06c8322b0bb29e91f48b009