### PR TITLE
Introduce DArrayIndexBuilder and serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.61.0"
 anyhow = "1.0"
 num-traits = "0.2.15"
 anybytes = { version = "0.19", features = ["zerocopy"] }
+zerocopy = "0.8"
 
 [features]
 default = ["std"]

--- a/src/bit_vectors/darray.rs
+++ b/src/bit_vectors/darray.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use crate::bit_vectors::prelude::*;
 use crate::bit_vectors::rank9sel::inner::Rank9SelIndex;
 use crate::bit_vectors::BitVector;
-use inner::DArrayIndex;
+use inner::{DArrayIndex, DArrayIndexBuilder};
 
 /// Constant-time select data structure over integer sets with the dense array technique.
 ///
@@ -70,7 +70,7 @@ impl DArray {
         I: IntoIterator<Item = bool>,
     {
         let bv = BitVector::from_bits(bits);
-        let s1 = DArrayIndex::new(&bv, true);
+        let s1 = DArrayIndexBuilder::new(&bv, true).build();
         Self {
             bv,
             s1,
@@ -89,7 +89,7 @@ impl DArray {
     /// Builds an index to enable select0.
     #[must_use]
     pub fn enable_select0(mut self) -> Self {
-        self.s0 = Some(DArrayIndex::new(&self.bv, false));
+        self.s0 = Some(DArrayIndexBuilder::new(&self.bv, false).build());
         self
     }
 


### PR DESCRIPTION
## Summary
- switch DArrayIndex internal arrays to `View` for zero-copy storage
- add `DArrayIndexBuilder` that freezes vectors with `Bytes`
- implement zero-copy `from_bytes`/`to_bytes`
- construct indices via the builder in `darray.rs`
- add serialization round-trip tests
- reorder serialized metadata so lengths precede data arrays

## Testing
- `cargo fmt`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6848411b3eb483228927eb185256f298