### PR TITLE
Rename library to jerky

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENT Instructions
 
-This repository contains the `sucds` Rust crate.
+This repository contains the `jerky` Rust crate.
 
 ## Project Priorities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Rename crate to `succdisk` to reflect on-disk succinct data structures.
+- Rename crate from `succdisk` to `jerky`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "sucds"
+name = "jerky"
 version = "0.8.1"
 authors = ["Shunsuke Kanda (kampersanda) <shnsk.knd@gmail.com>"]
-description = "Succinct data structures in Rust"
+description = "Succinct on-disk data structures in Rust"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-documentation = "https://docs.rs/sucds"
-repository = "https://github.com/triblespace/sucds"
-homepage = "https://github.com/triblespace/sucds"
+documentation = "https://docs.rs/jerky"
+repository = "https://github.com/triblespace/jerky"
+homepage = "https://github.com/triblespace/jerky"
 keywords = ["succinct", "compression"]
 categories = ["data-structures"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Succinct data structures in Rust
+# Succinct on-disk data structures in Rust
 
-![](https://github.com/triblespace/sucds/actions/workflows/rust.yml/badge.svg)
-[![Documentation](https://docs.rs/sucds/badge.svg)](https://docs.rs/sucds)
-[![Crates.io](https://img.shields.io/crates/v/sucds.svg)](https://crates.io/crates/sucds)
+![](https://github.com/triblespace/jerky/actions/workflows/rust.yml/badge.svg)
+[![Documentation](https://docs.rs/jerky/badge.svg)](https://docs.rs/jerky)
+[![Crates.io](https://img.shields.io/crates/v/jerky.svg)](https://crates.io/crates/jerky)
 
-Sucds provides some [succinct data structures](https://en.wikipedia.org/wiki/Succinct_data_structure) written in Rust.
+Jerky provides some [succinct data structures](https://en.wikipedia.org/wiki/Succinct_data_structure) written in Rust.
 
 ## Documentation
 
-https://docs.rs/sucds/
+https://docs.rs/jerky/
 
 ## Limitation
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "sucds-bench"
+name = "jerky-bench"
 version = "0.1.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sucds = { path = "..", features = ["intrinsics"] } # Recommend to set RUSTFLAGS="-C target-cpu=native"
+jerky = { path = "..", features = ["intrinsics"] } # Recommend to set RUSTFLAGS="-C target-cpu=native"
 rand = "0.8.4"
 rand_chacha = "0.3.1"
 suffix = "1.3.0"

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,4 +1,4 @@
-# sucds/bench
+# jerky/bench
 
 ## Benchmark for bit vectors
 

--- a/bench/benches/timing_bitvec_rank.rs
+++ b/bench/benches/timing_bitvec_rank.rs
@@ -7,7 +7,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
 
-use sucds::bit_vectors::Rank;
+use jerky::bit_vectors::Rank;
 
 const SAMPLE_SIZE: usize = 30;
 const WARM_UP_TIME: Duration = Duration::from_secs(5);
@@ -38,13 +38,13 @@ fn run_queries<R: Rank>(idx: &R, queries: &[usize]) {
 }
 
 fn perform_bitvec_rank(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], queries: &[usize]) {
-    group.bench_function("sucds/BitVector", |b| {
-        let idx = sucds::bit_vectors::BitVector::from_bits(bits.iter().cloned());
+    group.bench_function("jerky/BitVector", |b| {
+        let idx = jerky::bit_vectors::BitVector::from_bits(bits.iter().cloned());
         b.iter(|| run_queries(&idx, &queries));
     });
 
-    group.bench_function("sucds/Rank9Sel", |b| {
-        let idx = sucds::bit_vectors::Rank9Sel::from_bits(bits.iter().cloned());
+    group.bench_function("jerky/Rank9Sel", |b| {
+        let idx = jerky::bit_vectors::Rank9Sel::from_bits(bits.iter().cloned());
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/benches/timing_bitvec_select.rs
+++ b/bench/benches/timing_bitvec_select.rs
@@ -6,8 +6,8 @@ use rand_chacha::ChaChaRng;
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
-
-use sucds::bit_vectors::Select;
+use jerky::bit_vectors::Build;
+use jerky::bit_vectors::Select;
 
 const SAMPLE_SIZE: usize = 30;
 const WARM_UP_TIME: Duration = Duration::from_secs(5);
@@ -42,20 +42,20 @@ fn run_queries<S: Select>(idx: &S, queries: &[usize]) {
 }
 
 fn perform_bitvec_select(group: &mut BenchmarkGroup<WallTime>, bits: &[bool], queries: &[usize]) {
-    group.bench_function("sucds/BitVector", |b| {
-        let idx = sucds::bit_vectors::BitVector::from_bits(bits.iter().cloned());
+    group.bench_function("jerky/BitVector", |b| {
+        let idx = jerky::bit_vectors::BitVector::from_bits(bits.iter().cloned());
         b.iter(|| run_queries(&idx, &queries));
     });
 
-    group.bench_function("sucds/Rank9Sel", |b| {
+    group.bench_function("jerky/Rank9Sel", |b| {
         let idx =
-            sucds::bit_vectors::Rank9Sel::build_from_bits(bits.iter().cloned(), false, true, false)
+            jerky::bit_vectors::Rank9Sel::build_from_bits(bits.iter().cloned(), false, true, false)
                 .unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });
 
-    group.bench_function("sucds/DArray", |b| {
-        let idx = sucds::bit_vectors::DArray::from_bits(bits.iter().cloned());
+    group.bench_function("jerky/DArray", |b| {
+        let idx = jerky::bit_vectors::DArray::from_bits(bits.iter().cloned());
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/benches/timing_chrseq_access.rs
+++ b/bench/benches/timing_chrseq_access.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
-use sucds::bit_vectors::{prelude::*, BitVector};
-use sucds::int_vectors::CompactVector;
+use jerky::bit_vectors::{prelude::*, BitVector};
+use jerky::int_vectors::CompactVector;
 
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
@@ -71,7 +71,7 @@ fn criterion_chrseq_access_proteins(c: &mut Criterion) {
     perform_chrseq_access(&mut group, &text);
 }
 
-fn run_queries<B>(idx: &sucds::char_sequences::WaveletMatrix<B>, queries: &[usize])
+fn run_queries<B>(idx: &jerky::char_sequences::WaveletMatrix<B>, queries: &[usize])
 where
     B: Access + Build + NumBits + Rank + Select,
 {
@@ -87,16 +87,16 @@ where
 fn perform_chrseq_access(group: &mut BenchmarkGroup<WallTime>, text: &CompactVector) {
     let queries = gen_random_ints(NUM_QUERIES, 0, text.len(), SEED_QUERIES);
 
-    group.bench_function("sucds/WaveletMatrix<Rank9Sel>", |b| {
+    group.bench_function("jerky/WaveletMatrix<Rank9Sel>", |b| {
         let idx =
-            sucds::char_sequences::WaveletMatrix::<sucds::bit_vectors::Rank9Sel>::new(text.clone())
+            jerky::char_sequences::WaveletMatrix::<jerky::bit_vectors::Rank9Sel>::new(text.clone())
                 .unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });
 
-    group.bench_function("sucds/WaveletMatrix<DArray>", |b| {
+    group.bench_function("jerky/WaveletMatrix<DArray>", |b| {
         let idx =
-            sucds::char_sequences::WaveletMatrix::<sucds::bit_vectors::DArray>::new(text.clone())
+            jerky::char_sequences::WaveletMatrix::<jerky::bit_vectors::DArray>::new(text.clone())
                 .unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });

--- a/bench/benches/timing_intvec_access.rs
+++ b/bench/benches/timing_intvec_access.rs
@@ -7,7 +7,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
 
-use sucds::int_vectors::Access;
+use jerky::int_vectors::Access;
 
 const SAMPLE_SIZE: usize = 30;
 const WARM_UP_TIME: Duration = Duration::from_secs(5);
@@ -81,13 +81,13 @@ fn run_queries<G: Access>(idx: &G, queries: &[usize]) {
 fn perform_intvec_access(group: &mut BenchmarkGroup<WallTime>, vals: &[u32]) {
     let queries = gen_random_ints(NUM_QUERIES, 0, vals.len(), SEED_QUERIES);
 
-    group.bench_function("sucds/CompactVector", |b| {
-        let idx = sucds::int_vectors::CompactVector::from_slice(vals).unwrap();
+    group.bench_function("jerky/CompactVector", |b| {
+        let idx = jerky::int_vectors::CompactVector::from_slice(vals).unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });
 
-    group.bench_function("sucds/DacsByte", |b| {
-        let idx = sucds::int_vectors::DacsByte::from_slice(vals).unwrap();
+    group.bench_function("jerky/DacsByte", |b| {
+        let idx = jerky::int_vectors::DacsByte::from_slice(vals).unwrap();
         b.iter(|| run_queries(&idx, &queries));
     });
 }

--- a/bench/src/mem_bitvec.rs
+++ b/bench/src/mem_bitvec.rs
@@ -1,3 +1,4 @@
+use jerky::bit_vectors::Build;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
@@ -20,27 +21,27 @@ fn show_memories(p: f64) {
     println!("[p = {p}]");
 
     let bytes = {
-        let idx = sucds::bit_vectors::Rank9Sel::from_bits(bits.iter().cloned());
+        let idx = jerky::bit_vectors::Rank9Sel::from_bits(bits.iter().cloned());
         idx.size_in_bytes()
     };
     print_memory("Rank9Sel", bytes);
 
     let bytes = {
         let idx =
-            sucds::bit_vectors::Rank9Sel::build_from_bits(bits.iter().cloned(), false, true, true)
+            jerky::bit_vectors::Rank9Sel::build_from_bits(bits.iter().cloned(), false, true, true)
                 .unwrap();
         idx.size_in_bytes()
     };
     print_memory("Rank9Sel (with select hints)", bytes);
 
     let bytes = {
-        let idx = sucds::bit_vectors::DArray::from_bits(bits.iter().cloned());
+        let idx = jerky::bit_vectors::DArray::from_bits(bits.iter().cloned());
         idx.size_in_bytes()
     };
     print_memory("DArray", bytes);
 
     let bytes = {
-        let idx = sucds::bit_vectors::DArray::from_bits(bits.iter().cloned()).enable_rank();
+        let idx = jerky::bit_vectors::DArray::from_bits(bits.iter().cloned()).enable_rank();
         idx.size_in_bytes()
     };
     print_memory("DArray (with rank index)", bytes);

--- a/bench/src/mem_chrseq.rs
+++ b/bench/src/mem_chrseq.rs
@@ -1,5 +1,5 @@
-use sucds::bit_vectors::{BitVector, Rank};
-use sucds::int_vectors::CompactVector;
+use jerky::bit_vectors::{BitVector, Rank};
+use jerky::int_vectors::CompactVector;
 
 const DBLP_PSEF_STR: &str = include_str!("../data/texts/dblp.1MiB.txt");
 const DNA_PSEF_STR: &str = include_str!("../data/texts/dna.1MiB.txt");
@@ -29,7 +29,7 @@ fn show_memories(title: &str, text: &CompactVector) {
 
     let bytes = {
         let idx =
-            sucds::char_sequences::WaveletMatrix::<sucds::bit_vectors::Rank9Sel>::new(text.clone())
+            jerky::char_sequences::WaveletMatrix::<jerky::bit_vectors::Rank9Sel>::new(text.clone())
                 .unwrap();
         idx.size_in_bytes()
     };
@@ -37,7 +37,7 @@ fn show_memories(title: &str, text: &CompactVector) {
 
     let bytes = {
         let idx =
-            sucds::char_sequences::WaveletMatrix::<sucds::bit_vectors::DArray>::new(text.clone())
+            jerky::char_sequences::WaveletMatrix::<jerky::bit_vectors::DArray>::new(text.clone())
                 .unwrap();
         idx.size_in_bytes()
     };

--- a/bench/src/mem_intvec.rs
+++ b/bench/src/mem_intvec.rs
@@ -35,13 +35,13 @@ fn show_memories(title: &str, vals: &[u32]) {
     show_data_stats(vals);
 
     let bytes = {
-        let idx = sucds::int_vectors::CompactVector::from_slice(vals).unwrap();
+        let idx = jerky::int_vectors::CompactVector::from_slice(vals).unwrap();
         idx.size_in_bytes()
     };
     print_memory("CompactVector", bytes, vals.len());
 
     let bytes = {
-        let idx = sucds::int_vectors::DacsByte::from_slice(vals).unwrap();
+        let idx = jerky::int_vectors::DacsByte::from_slice(vals).unwrap();
         idx.size_in_bytes()
     };
     print_memory("DacsByte", bytes, vals.len());

--- a/src/bit_vectors.rs
+++ b/src/bit_vectors.rs
@@ -54,7 +54,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use sucds::bit_vectors::{Rank9Sel, prelude::*};
+//! use jerky::bit_vectors::{Rank9Sel, prelude::*};
 //!
 //! let bv = Rank9Sel::build_from_bits(
 //!     [true, false, false, true],

--- a/src/bit_vectors/bit_vector.rs
+++ b/src/bit_vectors/bit_vector.rs
@@ -16,7 +16,7 @@ pub const WORD_LEN: usize = std::mem::size_of::<usize>() * 8;
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use sucds::bit_vectors::BitVector;
+/// use jerky::bit_vectors::BitVector;
 ///
 /// let mut bv = BitVector::new();
 /// bv.push_bit(true);
@@ -46,7 +46,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::new();
     /// assert_eq!(bv.len(), 0);
@@ -64,7 +64,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::with_capacity(40);
     /// assert_eq!(bv.len(), 0);
@@ -88,7 +88,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bit(false, 5);
     /// assert_eq!(bv.len(), 5);
@@ -114,7 +114,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([false, true, false]);
     /// assert_eq!(bv.len(), 3);
@@ -138,7 +138,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([true, false, false]);
     /// assert_eq!(bv.get_bit(0), Some(true));
@@ -170,7 +170,7 @@ impl BitVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let mut bv = BitVector::from_bits([false, true, false]);
     /// bv.set_bit(1, false)?;
@@ -202,7 +202,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let mut bv = BitVector::new();
     /// bv.push_bit(true);
@@ -234,7 +234,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.get_bits(1, 2), Some(0b10));
@@ -288,7 +288,7 @@ impl BitVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let mut bv = BitVector::from_bit(false, 4);
     /// bv.set_bits(1, 0b11, 2)?;
@@ -358,7 +358,7 @@ impl BitVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let mut bv = BitVector::new();
     /// bv.push_bits(0b11, 2)?;
@@ -415,7 +415,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([false, true, false, true]);
     /// assert_eq!(bv.predecessor1(3), Some(3));
@@ -455,7 +455,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.predecessor0(3), Some(3));
@@ -495,7 +495,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.successor1(0), Some(0));
@@ -536,7 +536,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([false, true, false, true]);
     /// assert_eq!(bv.successor0(0), Some(0));
@@ -568,7 +568,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([false, true, false]);
     /// let mut it = bv.iter();
@@ -590,7 +590,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([true, true, false, true]);
     /// let mut it = bv.unary_iter(1);
@@ -612,7 +612,7 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([true, false, true, false]);
     /// assert_eq!(bv.get_word64(1), Some(0b10));
@@ -721,7 +721,7 @@ impl Access for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, Access};
+    /// use jerky::bit_vectors::{BitVector, Access};
     ///
     /// let bv = BitVector::from_bits([true, false, false]);
     /// assert_eq!(bv.access(0), Some(true));
@@ -750,7 +750,7 @@ impl Rank for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, Rank};
+    /// use jerky::bit_vectors::{BitVector, Rank};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.rank1(1), Some(1));
@@ -784,7 +784,7 @@ impl Rank for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, Rank};
+    /// use jerky::bit_vectors::{BitVector, Rank};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.rank0(1), Some(0));
@@ -809,7 +809,7 @@ impl Select for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, Select};
+    /// use jerky::bit_vectors::{BitVector, Select};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.select1(0), Some(0));
@@ -845,7 +845,7 @@ impl Select for BitVector {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, Select};
+    /// use jerky::bit_vectors::{BitVector, Select};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// assert_eq!(bv.select0(0), Some(1));

--- a/src/bit_vectors/bit_vector/unary.rs
+++ b/src/bit_vectors/bit_vector/unary.rs
@@ -29,7 +29,7 @@ impl<'a> UnaryIter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([false, true, false, false, true, true]);
     /// let mut it = bv.unary_iter(0);
@@ -67,7 +67,7 @@ impl<'a> UnaryIter<'a> {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::BitVector;
+    /// use jerky::bit_vectors::BitVector;
     ///
     /// let bv = BitVector::from_bits([false, true, false, false, true, true]);
     /// let mut it = bv.unary_iter(0);

--- a/src/bit_vectors/darray.rs
+++ b/src/bit_vectors/darray.rs
@@ -25,7 +25,7 @@ use inner::{DArrayIndex, DArrayIndexBuilder};
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use sucds::bit_vectors::{DArray, Access, Rank, Select};
+/// use jerky::bit_vectors::{DArray, Access, Rank, Select};
 ///
 /// let da = DArray::from_bits([true, false, false, true])
 ///     .enable_rank()
@@ -190,7 +190,7 @@ impl Access for DArray {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{DArray, Access};
+    /// use jerky::bit_vectors::{DArray, Access};
     ///
     /// let da = DArray::from_bits([true, false, false]);
     ///
@@ -219,7 +219,7 @@ impl Rank for DArray {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{DArray, Rank};
+    /// use jerky::bit_vectors::{DArray, Rank};
     ///
     /// let da = DArray::from_bits([true, false, false, true]).enable_rank();
     ///
@@ -248,7 +248,7 @@ impl Rank for DArray {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{DArray, Rank};
+    /// use jerky::bit_vectors::{DArray, Rank};
     ///
     /// let da = DArray::from_bits([true, false, false, true]).enable_rank();
     ///
@@ -275,7 +275,7 @@ impl Select for DArray {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{DArray, Select};
+    /// use jerky::bit_vectors::{DArray, Select};
     ///
     /// let da = DArray::from_bits([true, false, false, true]);
     ///
@@ -301,7 +301,7 @@ impl Select for DArray {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{DArray, Select};
+    /// use jerky::bit_vectors::{DArray, Select};
     ///
     /// let da = DArray::from_bits([true, false, false, true]).enable_select0();
     ///

--- a/src/bit_vectors/darray/inner.rs
+++ b/src/bit_vectors/darray/inner.rs
@@ -148,7 +148,7 @@ impl<const OVER_ONE: bool> DArrayIndex<OVER_ONE> {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, darray::inner::DArrayIndex};
+    /// use jerky::bit_vectors::{BitVector, darray::inner::DArrayIndex};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// let da = DArrayIndex::<true>::new(&bv);
@@ -164,7 +164,7 @@ impl<const OVER_ONE: bool> DArrayIndex<OVER_ONE> {
     /// `DArrayIndex::<false>::new(&bv)`.
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, darray::inner::DArrayIndex};
+    /// use jerky::bit_vectors::{BitVector, darray::inner::DArrayIndex};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// let da = DArrayIndex::<false>::new(&bv);

--- a/src/bit_vectors/prelude.rs
+++ b/src/bit_vectors/prelude.rs
@@ -4,6 +4,6 @@
 //!
 //! ```
 //! # #![allow(unused_imports)]
-//! use sucds::bit_vectors::prelude::*;
+//! use jerky::bit_vectors::prelude::*;
 //! ```
 pub use crate::bit_vectors::{Access, Build, NumBits, Rank, Select};

--- a/src/bit_vectors/rank9sel.rs
+++ b/src/bit_vectors/rank9sel.rs
@@ -26,7 +26,7 @@ use inner::{Rank9SelIndex, Rank9SelIndexBuilder};
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use sucds::bit_vectors::{Rank9Sel, Access, Rank, Select, Build};
+/// use jerky::bit_vectors::{Rank9Sel, Access, Rank, Select, Build};
 ///
 /// let bv = Rank9Sel::build_from_bits(
 ///     [true, false, false, true],
@@ -156,7 +156,7 @@ impl Access for Rank9Sel {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{Rank9Sel, Access};
+    /// use jerky::bit_vectors::{Rank9Sel, Access};
     ///
     /// let bv = Rank9Sel::from_bits([true, false, false]);
     ///
@@ -181,7 +181,7 @@ impl Rank for Rank9Sel {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{Rank9Sel, Rank};
+    /// use jerky::bit_vectors::{Rank9Sel, Rank};
     ///
     /// let bv = Rank9Sel::from_bits([true, false, false, true]);
     ///
@@ -205,7 +205,7 @@ impl Rank for Rank9Sel {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{Rank9Sel, Rank};
+    /// use jerky::bit_vectors::{Rank9Sel, Rank};
     ///
     /// let bv = Rank9Sel::from_bits([true, false, false, true]);
     ///
@@ -232,7 +232,7 @@ impl Select for Rank9Sel {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::{Rank9Sel, Select, Build};
+    /// use jerky::bit_vectors::{Rank9Sel, Select, Build};
     ///
     /// let bv = Rank9Sel::build_from_bits([true, false, false, true], false, true, false)?;
     ///
@@ -257,7 +257,7 @@ impl Select for Rank9Sel {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::{Rank9Sel, Select, Build};
+    /// use jerky::bit_vectors::{Rank9Sel, Select, Build};
     ///
     /// let bv = Rank9Sel::build_from_bits([true, false, false, true], false, false, true)?;
     ///

--- a/src/bit_vectors/rank9sel/inner.rs
+++ b/src/bit_vectors/rank9sel/inner.rs
@@ -225,7 +225,7 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndex::new(&bv);
@@ -272,7 +272,7 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndex::new(&bv);
@@ -308,7 +308,7 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndexBuilder::new(&bv).select1_hints().build();
@@ -384,7 +384,7 @@ impl Rank9SelIndex {
     /// # Examples
     ///
     /// ```
-    /// use sucds::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
+    /// use jerky::bit_vectors::{BitVector, rank9sel::inner::{Rank9SelIndex, Rank9SelIndexBuilder}};
     ///
     /// let bv = BitVector::from_bits([true, false, false, true]);
     /// let idx = Rank9SelIndexBuilder::new(&bv).select0_hints().build();

--- a/src/broadword.rs
+++ b/src/broadword.rs
@@ -46,7 +46,7 @@ pub(crate) const fn bytes_sum(x: usize) -> usize {
 /// # Examples
 ///
 /// ```
-/// use sucds::broadword::popcount;
+/// use jerky::broadword::popcount;
 ///
 /// assert_eq!(popcount(0), 0);
 /// assert_eq!(popcount(usize::MAX), 64);
@@ -70,7 +70,7 @@ pub const fn popcount(x: usize) -> usize {
 /// # Examples
 ///
 /// ```
-/// use sucds::broadword::select_in_word;
+/// use jerky::broadword::select_in_word;
 ///
 /// assert_eq!(select_in_word(0b1000011, 0), Some(0));
 /// assert_eq!(select_in_word(0b1000011, 1), Some(1));
@@ -111,7 +111,7 @@ pub(crate) fn bit_position(x: usize) -> usize {
 /// # Examples
 ///
 /// ```
-/// use sucds::broadword::lsb;
+/// use jerky::broadword::lsb;
 ///
 /// assert_eq!(lsb(0b101100), Some(2));
 /// assert_eq!(lsb(0b0), None);
@@ -138,7 +138,7 @@ pub fn lsb(x: usize) -> Option<usize> {
 /// # Examples
 ///
 /// ```
-/// use sucds::broadword::msb;
+/// use jerky::broadword::msb;
 ///
 /// assert_eq!(msb(0b101100), Some(5));
 /// assert_eq!(msb(0b0), None);

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -22,9 +22,9 @@ use crate::utils;
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use sucds::bit_vectors::Rank9Sel;
-/// use sucds::char_sequences::WaveletMatrix;
-/// use sucds::int_vectors::CompactVector;
+/// use jerky::bit_vectors::Rank9Sel;
+/// use jerky::char_sequences::WaveletMatrix;
+/// use jerky::int_vectors::CompactVector;
 ///
 /// let text = "banana";
 /// let len = text.chars().count();
@@ -140,9 +140,9 @@ where
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::Rank9Sel;
-    /// use sucds::char_sequences::WaveletMatrix;
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::bit_vectors::Rank9Sel;
+    /// use jerky::char_sequences::WaveletMatrix;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
     /// seq.extend("banana".chars().map(|c| c as usize))?;
@@ -190,9 +190,9 @@ where
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::Rank9Sel;
-    /// use sucds::char_sequences::WaveletMatrix;
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::bit_vectors::Rank9Sel;
+    /// use jerky::char_sequences::WaveletMatrix;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
     /// seq.extend("banana".chars().map(|c| c as usize))?;
@@ -225,9 +225,9 @@ where
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::Rank9Sel;
-    /// use sucds::char_sequences::WaveletMatrix;
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::bit_vectors::Rank9Sel;
+    /// use jerky::char_sequences::WaveletMatrix;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
     /// seq.extend("banana".chars().map(|c| c as usize))?;
@@ -281,9 +281,9 @@ where
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::Rank9Sel;
-    /// use sucds::char_sequences::WaveletMatrix;
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::bit_vectors::Rank9Sel;
+    /// use jerky::char_sequences::WaveletMatrix;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
     /// seq.extend("banana".chars().map(|c| c as usize))?;
@@ -342,9 +342,9 @@ where
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::Rank9Sel;
-    /// use sucds::char_sequences::WaveletMatrix;
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::bit_vectors::Rank9Sel;
+    /// use jerky::char_sequences::WaveletMatrix;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
     /// seq.extend("banana".chars().map(|c| c as usize))?;
@@ -410,9 +410,9 @@ where
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::Rank9Sel;
-    /// use sucds::char_sequences::WaveletMatrix;
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::bit_vectors::Rank9Sel;
+    /// use jerky::char_sequences::WaveletMatrix;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
     /// seq.extend("banana".chars().map(|c| c as usize))?;
@@ -516,9 +516,9 @@ where
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::bit_vectors::Rank9Sel;
-    /// use sucds::char_sequences::WaveletMatrix;
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::bit_vectors::Rank9Sel;
+    /// use jerky::char_sequences::WaveletMatrix;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
     /// seq.extend("ban".chars().map(|c| c as usize))?;

--- a/src/int_vectors.rs
+++ b/src/int_vectors.rs
@@ -56,7 +56,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use sucds::int_vectors::{DacsByte, prelude::*};
+//! use jerky::int_vectors::{DacsByte, prelude::*};
 //!
 //! let seq = DacsByte::build_from_slice(&[5, 0, 100000, 334])?;
 //!

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -18,7 +18,7 @@ use crate::utils;
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use sucds::int_vectors::CompactVector;
+/// use jerky::int_vectors::CompactVector;
 ///
 /// // Can store integers within 3 bits each.
 /// let mut cv = CompactVector::new(3)?;
@@ -56,7 +56,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::new(3)?;
     /// assert_eq!(cv.len(), 0);
@@ -91,7 +91,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::with_capacity(10, 3)?;
     ///
@@ -134,7 +134,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::from_int(7, 2, 3)?;
     /// assert_eq!(cv.len(), 2);
@@ -177,7 +177,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::from_slice(&[7, 2])?;
     /// assert_eq!(cv.len(), 2);
@@ -222,7 +222,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let cv = CompactVector::from_slice(&[5, 256, 0])?;
     /// assert_eq!(cv.get_int(0), Some(5));
@@ -257,7 +257,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::from_int(0, 2, 3)?;
     /// cv.set_int(1, 4)?;
@@ -304,7 +304,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::new(3)?;
     /// cv.push_int(2)?;
@@ -345,7 +345,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::new(3)?;
     /// cv.extend([2, 1, 3])?;
@@ -369,7 +369,7 @@ impl CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::CompactVector;
+    /// use jerky::int_vectors::CompactVector;
     ///
     /// let cv = CompactVector::from_slice(&[5, 256, 0])?;
     /// let mut it = cv.iter();
@@ -445,7 +445,7 @@ impl Access for CompactVector {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::{CompactVector, Access};
+    /// use jerky::int_vectors::{CompactVector, Access};
     ///
     /// let cv = CompactVector::from_slice(&[5, 256, 0])?;
     /// assert_eq!(cv.access(0), Some(5));

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -30,7 +30,7 @@ const LEVEL_MASK: usize = (1 << LEVEL_WIDTH) - 1;
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use sucds::int_vectors::{DacsByte, Access};
+/// use jerky::int_vectors::{DacsByte, Access};
 ///
 /// let seq = DacsByte::from_slice(&[5, 0, 100000, 334])?;
 ///
@@ -124,7 +124,7 @@ impl DacsByte {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::DacsByte;
+    /// use jerky::int_vectors::DacsByte;
     ///
     /// let seq = DacsByte::from_slice(&[5, 0, 100000, 334])?;
     /// let mut it = seq.iter();
@@ -208,7 +208,7 @@ impl Access for DacsByte {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sucds::int_vectors::{DacsByte, Access};
+    /// use jerky::int_vectors::{DacsByte, Access};
     ///
     /// let seq = DacsByte::from_slice(&[5, 999, 334])?;
     ///

--- a/src/int_vectors/prelude.rs
+++ b/src/int_vectors/prelude.rs
@@ -4,6 +4,6 @@
 //!
 //! ```
 //! # #![allow(unused_imports)]
-//! use sucds::int_vectors::prelude::*;
+//! use jerky::int_vectors::prelude::*;
 //! ```
 pub use crate::int_vectors::{Access, Build, NumVals};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Succinct data structures in Rust
 //!
-//! Sucds is a collection of [succinct data structures](https://en.wikipedia.org/wiki/Succinct_data_structure),
+//! Jerky is a collection of [succinct data structures](https://en.wikipedia.org/wiki/Succinct_data_structure),
 //! powerful tools to store a variety of data structures in compressed space and
 //! quickly perform operations on the compressed data.
 //!
@@ -11,18 +11,18 @@
 //! To handle them in a single crate, we set up several design policies:
 //!
 //! - **Maintain interface consistency:**
-//!   Sucds will adhere to a unified interface, facilitating the integration and replacement of data structures.
+//!   Jerky will adhere to a unified interface, facilitating the integration and replacement of data structures.
 //!
 //! - **Preserve identity:**
 //!   Rather than offering every possible succinct data structure,
-//!   Sucds will focus on providing only those that hold a competitive advantage over others.
+//!   Jerky will focus on providing only those that hold a competitive advantage over others.
 //!
 //! - **Ensure safety:**
-//!   To avoid potential risks, Sucds will refrain from using unsafe instructions
+//!   To avoid potential risks, Jerky will refrain from using unsafe instructions
 //!   typically reserved for extremely low-level programming.
 //!
 //! - **Remain Rust-centric:**
-//!   Sucds will consistently utilize Pure Rust in its implementation.
+//!   Jerky will consistently utilize Pure Rust in its implementation.
 //!
 //! ## Data structures
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use crate::broadword;
 /// # Examples
 ///
 /// ```
-/// use sucds::utils::needed_bits;
+/// use jerky::utils::needed_bits;
 ///
 /// assert_eq!(needed_bits(0), 1);
 /// assert_eq!(needed_bits(1), 1);
@@ -25,7 +25,7 @@ pub fn needed_bits(x: usize) -> usize {
 /// # Examples
 ///
 /// ```
-/// use sucds::utils::ceiled_divide;
+/// use jerky::utils::ceiled_divide;
 ///
 /// assert_eq!(ceiled_divide(10, 2), 5);
 /// assert_eq!(ceiled_divide(10, 3), 4);


### PR DESCRIPTION
## Summary
- rename crate to `jerky`
- update documentation, README, and AGENT instructions for new crate name
- adjust benchmark crate and examples for `jerky`
- document rename in `CHANGELOG`

## Testing
- `cargo test --workspace --exclude jerky-bench`


------
https://chatgpt.com/codex/tasks/task_e_6867cea864188322b421d54dd0752886