### PR TITLE
Add BitVectorBuilder and zero-copy BitVectorData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Added `BitVectorBuilder` and zero-copy `BitVectorData` backed by `anybytes::View`.
+- Introduced `IndexBuilder` trait with a `Built` type and adjusted serialization helpers.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ The document can be compiled with the following command:
 RUSTDOCFLAGS="--html-in-header katex.html" cargo doc --no-deps
 ```
 
+## Zero-copy bit vectors
+
+`BitVectorBuilder` can build a bit vector whose underlying `BitVectorData`
+is backed by `anybytes::View`. The data can be serialized with
+`BitVectorData::to_bytes` and reconstructed using `BitVectorData::from_bytes`,
+allowing zero-copy loading from an mmap or any other source by passing the
+byte region to `Bytes::from_source`.
+
 ## Licensing
 
 Licensed under either of

--- a/src/bit_vectors.rs
+++ b/src/bit_vectors.rs
@@ -84,7 +84,9 @@ pub mod rank9sel;
 
 pub use bit_vector::BitVector;
 pub use darray::DArray;
-pub use data::{BitVector as IndexedBitVector, BitVectorData, BitVectorIndex, NoIndex};
+pub use data::{
+    BitVector as IndexedBitVector, BitVectorData, BitVectorIndex, IndexBuilder, NoIndex,
+};
 pub use rank9sel::Rank9Sel;
 
 use anyhow::Result;


### PR DESCRIPTION
## Summary
- document zero-copy builder in README
- add `BitVectorBuilder` for collecting bits
- store bit vector words in `anybytes::View` for mmap-friendly loading
- add tests for builder and from-bytes roundtrip
- clarify docs about `IndexBuilder` in CHANGELOG

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6867e3361efc8322b4dd92b3df6e3961